### PR TITLE
Issue 92 - Test 4

### DIFF
--- a/tools/autopr/src/env.ts
+++ b/tools/autopr/src/env.ts
@@ -14,7 +14,7 @@ async function init_globalCtx(): Promise<GlobalCtx> {
   
   return {
     // The root of the repository is the same folder with the package-lock.json in it
-    root: await package_lock_json_dir()
+    root: process.env.GITHUB_WORKSPACE || await package_lock_json_dir()
   };
 }
 


### PR DESCRIPTION
the GITHUB_WORKSPACE env var should be used when package-lock.json is deleted